### PR TITLE
Add a skeletal speakers section

### DIFF
--- a/src/sections/Speakers/Speakers.js
+++ b/src/sections/Speakers/Speakers.js
@@ -2,6 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import PersonCard from '../../components/PersonCard/PersonCard';
 import Styles from './Speakers.module.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+   faChevronCircleLeft,
+   faChevronCircleRight,
+} from '@fortawesome/free-solid-svg-icons';
 
 class Speakers extends React.Component {
    static propTypes = {
@@ -13,32 +18,65 @@ class Speakers extends React.Component {
          backdrop: PropTypes.string,
       }),
    };
+   cardScroll = e => {
+      let index = Math.floor(
+         e.target.scrollLeft / (screen.width < 400 ? screen.width : 400),
+      );
+      console.log(index);
+   };
    render() {
       const people = this.props.people.map((person, index) => {
          return (
-            <div key={index} className={Styles.speakerCard}>
-               <div className={Styles.backdropWrapper}>
-                  <img src={person.backdrop} className={Styles.backdrop} />
-               </div>
-               <div className={Styles.infoCard}>
-                  <PersonCard
-                     name={person.name}
-                     designation={person.designation}
-                     photo={person.photo}
-                     about={person.about}
-                  />
+            <div key={index} className={Styles.speakerCardWrapper}>
+               <div className={Styles.speakerCard}>
+                  <div className={Styles.backdropWrapper}>
+                     <img src={person.backdrop} className={Styles.backdrop} />
+                  </div>
+                  <div className={Styles.infoCard}>
+                     <PersonCard
+                        name={person.name}
+                        designation={person.designation}
+                        photo={person.photo}
+                        about={person.about}
+                     />
+                  </div>
                </div>
             </div>
          );
       });
+      const indicators = this.props.people.map((_person, index) => {
+         return <span key={index} className={Styles.cardsIndicator} />;
+      });
+      // Add first item again to last so we can have consistent animation going from last item to first
+      people.push(people[0]);
       return (
          <div className={Styles.speakersContainer}>
             <h2>Speakers</h2>
             <h5>
-               We focus on ergonomics and meeting you where you work.
-               It`&apos;`s only a keystroke away.
+               We focus on ergonomics and meeting you where you work. It&apos;s
+               only a keystroke away.
             </h5>
-            {people}
+            <div className={Styles.speakersCarousel}>
+               <div
+                  className={Styles.cardsContainer}
+                  onScroll={this.cardScroll}
+               >
+                  {people}
+               </div>
+               <div className={Styles.cardsPagination}>
+                  <FontAwesomeIcon
+                     icon={faChevronCircleLeft}
+                     className={Styles.changeCardIcon}
+                     size="2x"
+                  />
+                  <div className={Styles.indicatorWrapper}>{indicators}</div>
+                  <FontAwesomeIcon
+                     icon={faChevronCircleRight}
+                     className={Styles.changeCardIcon}
+                     size="2x"
+                  />
+               </div>
+            </div>
          </div>
       );
    }

--- a/src/sections/Speakers/Speakers.js
+++ b/src/sections/Speakers/Speakers.js
@@ -47,8 +47,11 @@ class Speakers extends React.Component {
       const indicators = this.props.people.map((_person, index) => {
          return <span key={index} className={Styles.cardsIndicator} />;
       });
-      // Add first item again to last so we can have consistent animation going from last item to first
+      // Add first three items again to last so we can have consistent
+      // animation going from last item to first
       people.push(people[0]);
+      people.push(people[1]);
+      people.push(people[2]);
       return (
          <div className={Styles.speakersContainer}>
             <h2>Speakers</h2>

--- a/src/sections/Speakers/Speakers.js
+++ b/src/sections/Speakers/Speakers.js
@@ -17,7 +17,9 @@ class Speakers extends React.Component {
       const people = this.props.people.map((person, index) => {
          return (
             <div key={index} className={Styles.speakerCard}>
-               <img src={person.backdrop} className={Styles.backdrop} />
+               <div className={Styles.backdropWrapper}>
+                  <img src={person.backdrop} className={Styles.backdrop} />
+               </div>
                <div className={Styles.infoCard}>
                   <PersonCard
                      name={person.name}

--- a/src/sections/Speakers/Speakers.module.scss
+++ b/src/sections/Speakers/Speakers.module.scss
@@ -4,20 +4,28 @@
     flex-wrap: wrap;
     justify-content: center;
     .speakerCard {
-        --dark-background: #181818;
+        --primary: #181818;
         --text-color: white;
         width: 29rem;
+        display: flex;
+        flex-direction: column;
         margin: 0.5rem;
         justify-content: center;
-        .backdrop{
-            width: calc(100% - 3rem);
-            aspect-ratio: 44/32;
-            object-fit: cover;
+        .backdropWrapper {
+            width: 90%;
+            height: 50%;
+            overflow: visible;
+            .backdrop {
+                width: 100%;
+                height: 125%;
+                object-fit: cover;
+            }
         }
         .infoCard {
-            transform: translate(2rem, -2rem);
-            width: calc(100% - 3rem);
             display: flex;
+            margin-left: 10%;
+            width: 90%;
+            max-height: 20rem;
         }
     }
 }

--- a/src/sections/Speakers/Speakers.module.scss
+++ b/src/sections/Speakers/Speakers.module.scss
@@ -5,6 +5,7 @@
     width: 100%;
     padding: 0 0.5rem;
     margin: 0 auto;
+    --max-card-size: 25rem;
     .speakersCarousel {
         display: flex;
         flex-direction: column;
@@ -17,14 +18,14 @@
             align-self: center;
             grid-template-rows: max-content;
             max-width: calc(100vw - 1rem);
-            @media only screen and (min-width: 26rem) {
-                max-width: 25rem;                
+            @media only screen and (min-width: calc(1rem + (1*var(--max-card-size)))) {
+                max-width: var(--max-card-size);
             }
-            @media only screen and (min-width: 51rem) {
-                max-width: 50rem;                
+            @media only screen and (min-width: calc(1rem + (2*var(--max-card-size)))) {
+                max-width: calc(2 * var(--max-card-size));
             }
-            @media only screen and (min-width: 76rem) {
-                max-width: 75rem;                
+            @media only screen and (min-width: calc(1rem + (1*var(--max-card-size)))) {
+                max-width: calc(3 * var(--max-card-size));
             }
             overflow-x: auto;
             scroll-snap-type: x mandatory;
@@ -34,13 +35,13 @@
                 }
                 scroll-snap-align: start;
                 width: calc(100vw - 1rem);
-                max-width: 25rem;
+                max-width: var(--max-card-size);
                 grid-row: 1/1;
                 .speakerCard {
                     display: flex;
                     flex-direction: column;
                     position: relative;
-                    max-width: 25rem;
+                    max-width: var(--max-card-size);
                     margin: 0.5rem;
                     justify-content: center;
                     .backdropWrapper {
@@ -73,16 +74,6 @@
                 display: flex;
                 flex-wrap: wrap;
                 justify-items: center;
-                @media only screen and (min-width: 51rem) {
-                    :last-child{
-                        display: none;
-                    }
-                }
-                @media only screen and (min-width: 76rem) {
-                    :nth-last-child(2){
-                        display: none;
-                    }
-                }
                 .cardsIndicator {
                     width: 1rem;
                     height: 1rem;

--- a/src/sections/Speakers/Speakers.module.scss
+++ b/src/sections/Speakers/Speakers.module.scss
@@ -4,19 +4,19 @@
     flex-wrap: wrap;
     justify-content: center;
     .speakerCard {
-        display: flex;
-        flex-direction: column;
-        flex: 1 0 31%;
-        margin: 5px;
+        --dark-background: #181818;
+        --text-color: white;
+        width: 29rem;
+        margin: 0.5rem;
         justify-content: center;
         .backdrop{
-            width: calc(100% - 40px);
-            aspect-ratio: 42/32;
+            width: calc(100% - 3rem);
+            aspect-ratio: 44/32;
             object-fit: cover;
         }
         .infoCard {
-            transform: translate(40px, -50px);
-            width: calc(100% - 40px);
+            transform: translate(2rem, -2rem);
+            width: calc(100% - 3rem);
             display: flex;
         }
     }

--- a/src/sections/Speakers/Speakers.module.scss
+++ b/src/sections/Speakers/Speakers.module.scss
@@ -1,31 +1,96 @@
 .speakersContainer {
     display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    .speakerCard {
-        --primary: #181818;
-        --text-color: white;
-        width: 29rem;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    padding: 0 0.5rem;
+    margin: 0 auto;
+    .speakersCarousel {
         display: flex;
         flex-direction: column;
-        margin: 0.5rem;
-        justify-content: center;
-        .backdropWrapper {
-            width: 90%;
-            height: 50%;
-            overflow: visible;
-            .backdrop {
-                width: 100%;
-                height: 125%;
-                object-fit: cover;
+        overflow: hidden;
+        ::-webkit-scrollbar{
+            display: none;
+        }
+        .cardsContainer {
+            display: grid;
+            align-self: center;
+            grid-template-rows: max-content;
+            max-width: calc(100vw - 1rem);
+            @media only screen and (min-width: 26rem) {
+                max-width: 25rem;                
+            }
+            @media only screen and (min-width: 51rem) {
+                max-width: 50rem;                
+            }
+            @media only screen and (min-width: 76rem) {
+                max-width: 75rem;                
+            }
+            overflow-x: auto;
+            scroll-snap-type: x mandatory;
+            .speakerCardWrapper {
+                ::-webkit-scrollbar{
+                    display: inline;
+                }
+                scroll-snap-align: start;
+                width: calc(100vw - 1rem);
+                max-width: 25rem;
+                grid-row: 1/1;
+                .speakerCard {
+                    display: flex;
+                    flex-direction: column;
+                    position: relative;
+                    max-width: 25rem;
+                    margin: 0.5rem;
+                    justify-content: center;
+                    .backdropWrapper {
+                        width: 90%;
+                        height: 50%;
+                        overflow: visible;
+                        .backdrop {
+                            width: 100%;
+                            height: 125%;
+                            object-fit: fill;
+                        }
+                    }
+                    .infoCard {
+                        display: flex;
+                        margin-left: 10%;
+                        width: 90%;
+                        max-height: 20rem;
+                    }
+                }
             }
         }
-        .infoCard {
+        .cardsPagination {
             display: flex;
-            margin-left: 10%;
-            width: 90%;
-            max-height: 20rem;
+            margin: 0 auto;
+            align-items: center;
+            .changeCardIcon {
+                margin: 0.4rem;
+            }
+            .indicatorWrapper{
+                display: flex;
+                flex-wrap: wrap;
+                justify-items: center;
+                @media only screen and (min-width: 51rem) {
+                    :last-child{
+                        display: none;
+                    }
+                }
+                @media only screen and (min-width: 76rem) {
+                    :nth-last-child(2){
+                        display: none;
+                    }
+                }
+                .cardsIndicator {
+                    width: 1rem;
+                    height: 1rem;
+                    margin: 0.2rem;
+                    border-radius: 50%;
+                    background-color: #FFFFFF44;
+                }
+            }
         }
     }
 }

--- a/src/sections/Team/Team.module.scss
+++ b/src/sections/Team/Team.module.scss
@@ -2,9 +2,10 @@
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     display: flex;
     flex-direction: column;
+    align-items: center;
     width: 100%;
-    background: var(--primary);
-    color: var(--text-color);
+    padding: 0 0.5rem;
+    margin: 0 auto;
     .teamName{
         width: 100%;
         text-align: center;

--- a/src/sections/Testimonials/Testimonials.module.scss
+++ b/src/sections/Testimonials/Testimonials.module.scss
@@ -2,8 +2,10 @@
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     display: flex;
     flex-direction: column;
-    background: var(--primary);
-    color: var(--text-color);
+    align-items: center;
+    width: 100%;
+    padding: 0 0.5rem;
+    margin: 0 auto;
     .testimonialMembers {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
Speakers section is complete in terms of HTML and CSS, only JS needs to be implemented. Dots are automatically hidden according to 2/3 cards visible using CSS
Screenshots: 
1440p wide:
![image](https://user-images.githubusercontent.com/44370143/126632623-9007b260-1738-4549-b940-acd3e9fa6da2.png)
1024p wide:
![image](https://user-images.githubusercontent.com/44370143/126632671-2be0538b-b222-4377-8650-76556efab3ba.png)
iPhone X dimensions:
![image](https://user-images.githubusercontent.com/44370143/126632776-e9f25df9-ef7a-4167-b45d-604480ecda15.png)
